### PR TITLE
Add prop-types as a separate dependency to avoid warning in console.

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,15 +6,14 @@
     "type": "git",
     "url": "git://github.com/dibenso/pagination-component.git"
   },
-  "files": ["umd"],
-  "main": "lib/index.js",
-  "module": "es/index.js",
   "files": [
     "css",
     "es",
     "lib",
     "umd"
   ],
+  "main": "lib/index.js",
+  "module": "es/index.js",
   "scripts": {
     "build": "nwb build-react-component",
     "clean": "nwb clean-module && npm clean-demo",
@@ -22,7 +21,9 @@
     "test": "nwb test-react",
     "test:watch": "nwb test-react --server"
   },
-  "dependencies": {},
+  "dependencies": {
+    "prop-types": "^15.5.10"
+  },
   "peerDependencies": {
     "react": "15.x"
   },

--- a/src/Link.js
+++ b/src/Link.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 
 class Link extends React.Component {
   static propTypes = {

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,5 @@
-import React, { PropTypes } from 'react';
+import React from 'react';
+import PropTypes from 'prop-types';
 import Link from './Link';
 
 class Pagination extends React.Component {


### PR DESCRIPTION
When importing  PropTypes from 'react', a warning is printed to the console. To avoid this, I'm pulling PropTypes in from the separate npm package they made for it.